### PR TITLE
Bugfixing

### DIFF
--- a/js/dncalendar.js
+++ b/js/dncalendar.js
@@ -589,7 +589,7 @@
                   month = month + 1;
 
                   if (month >= 12) {
-                    month = 0;
+                    month = 1;
                     year = year + 1;
                   }
                 }


### PR DESCRIPTION
In the context of this project month 0 does not exists.
The bug appears when in december you click on the firsts days of the next month, january and the calendar remains in december.